### PR TITLE
Remove cardFormData and setCardFormData function from payment context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Removed
-- Method `setCardFormData` and `cardFormData` from payment context.
+- `setCardFormData` and `cardFormData` from payment context.
 
 ## [0.3.0] - 2020-05-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Method `setCardFormData` and `cardFormData` from payment context.
 
 ## [0.3.0] - 2020-05-12
-## Added
+### Added
 - `setPaymentField` method to update a field of payment 
 - Get data from `OrderForm` and send to `children`
 

--- a/react/OrderPayment.tsx
+++ b/react/OrderPayment.tsx
@@ -4,7 +4,6 @@ import React, {
   useContext,
   useCallback,
   useMemo,
-  useState,
 } from 'react'
 import { useMutation } from 'react-apollo'
 import MutationUpdateOrderFormPayment from 'vtex.checkout-resources/MutationUpdateOrderFormPayment'
@@ -30,20 +29,10 @@ interface UpdateOrderFormPaymentMutationVariables {
   paymentData: PaymentDataInput
 }
 
-interface CardFormData {
-  encryptedCardNumber: string
-  encryptedCardHolder: string
-  encryptedExpiryDate: string
-  encryptedCsc: string
-  lastDigits: string
-}
-
 interface Context {
   setPaymentField: (
     paymentField: Partial<PaymentInput>
   ) => Promise<{ success: boolean }>
-  cardFormData: CardFormData | null
-  setCardFormData: React.Dispatch<React.SetStateAction<CardFormData | null>>
   paymentSystems: PaymentSystem[]
   availableAccounts: AvailableAccount[]
   installmentOptions: InstallmentOption[]
@@ -74,10 +63,9 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       payments,
     },
   } = orderForm
-  const referenceValue = totalizers[0]!.value
-  const payment = payments[0] || {}
 
-  const [cardFormData, setCardFormData] = useState<CardFormData | null>(null)
+  const referenceValue = totalizers[0]?.value ?? 0
+  const payment = payments[0] || {}
 
   const queueStatusRef = useQueueStatus(listen)
 
@@ -133,8 +121,6 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
   const value = useMemo(
     () => ({
       setPaymentField,
-      cardFormData,
-      setCardFormData,
       paymentSystems,
       installmentOptions,
       availableAccounts,
@@ -143,7 +129,6 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
     }),
     [
       availableAccounts,
-      cardFormData,
       installmentOptions,
       payment,
       paymentSystems,


### PR DESCRIPTION
#### What problem is this solving?

This PR removes the `cardFormData` and `setCardFormData`, as we won't be able to retrieve these values from the PCI environment.

[CHUI-10](https://vtex-dev.atlassian.net/browse/CHUI-10?atlOrigin=eyJpIjoiNTAwNDJkZTlkMjNkNDY3OWI0OTZlOTg2YjlhYTE2OTQiLCJwIjoiaiJ9)

#### How should this be manually tested?

[Workspace](https://shp--checkoutio.myvtex.com/checkout/#/payment). FYI that the payment step refactor is still WIP.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a ~Clubhouse~ JIRA story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->