### PR TITLE
Add cardLastDigits and setCardLastDigits properties to context value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cardLastDigits` and `setCardLastDigits` to context.
 
 ## [0.4.0] - 2020-06-01
 ### Removed

--- a/react/OrderPayment.tsx
+++ b/react/OrderPayment.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useCallback,
   useMemo,
+  useState,
 } from 'react'
 import { useMutation } from 'react-apollo'
 import MutationUpdateOrderFormPayment from 'vtex.checkout-resources/MutationUpdateOrderFormPayment'
@@ -38,6 +39,8 @@ interface Context {
   installmentOptions: InstallmentOption[]
   payment: Payment
   referenceValue: number
+  cardLastDigits: string
+  setCardLastDigits: (cardDigits: string) => void
 }
 
 interface OrderPaymentProps {
@@ -53,6 +56,7 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
 }: OrderPaymentProps) => {
   const { enqueue, listen } = useOrderQueue()
   const { orderForm, setOrderForm } = useOrderForm()
+  const [cardLastDigits, setCardLastDigits] = useState('')
 
   const {
     totalizers,
@@ -126,6 +130,8 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       availableAccounts,
       payment,
       referenceValue,
+      cardLastDigits,
+      setCardLastDigits,
     }),
     [
       availableAccounts,
@@ -134,6 +140,7 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       paymentSystems,
       referenceValue,
       setPaymentField,
+      cardLastDigits,
     ]
   )
 


### PR DESCRIPTION
#### What problem is this solving?

Adds the properties `cardLastDigits` and `setCardLastDigits`, as these infos are safe to retrieve from a PCI environment and will be needed to display to the user which card they will be using the place the order.

[CHUI-10](https://vtex-dev.atlassian.net/browse/CHUI-10?atlOrigin=eyJpIjoiOTRhNGFhNzE3MmFmNDYxYjhhMzZhOTNlODAzYThiYWIiLCJwIjoiaiJ9)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a ~Clubhouse~ Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->