### PR TITLE
Add fields value and interestValue to payment context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Fields `value` and `interestValue` to payment context.
+
+### Changed
+- Updated calculation for `referenceValue` to take into account all totalizers.
 
 ## [0.5.0] - 2020-06-02
 ### Added


### PR DESCRIPTION
#### What problem is this solving?

Adds the fields `interestValue` and `value` to be used in the place order flow. Also updates the calculation for the `referenceValue` to take into account all totalizers, except for taxes and interest. This is more aligned with the calculations the current checkout does.

#### How should this be manually tested?

[Workspace](https://placeorder--checkoutio.myvtex.com/cart).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->