### PR TITLE
CHK-90: Add setCardFormFilled and paymentsValid to payment context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `setCardFormFilled` and `paymentsValid` properties to payment context.
 
 ## [0.6.0] - 2020-06-04
 ### Added

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -3,41 +3,25 @@
     "alwaysStrict": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": [
-      "es2017",
-      "dom",
-      "es2018.promise"
-    ],
+    "lib": ["es2017", "dom", "es2018.promise"],
     "module": "esnext",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "skipLibCheck": true,
     "sourceMap": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "target": "es2017",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "types": [
-      "node",
-      "jest",
-      "graphql"
-    ]
+    "typeRoots": ["node_modules/@types"],
+    "types": ["node", "jest", "graphql"]
   },
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "./typings/*.d.ts",
-    "./**/*.tsx",
-    "./**/*.ts"
-  ],
+  "exclude": ["node_modules"],
+  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"],
   "typeAcquisition": {
     "enable": false
   }


### PR DESCRIPTION
#### What problem is this solving?

This PR is the first in a set of changes to move the validation of the payment data to the client. The basic idea was to move it to here, so we can access it in `checkout-container`, and for payments that require you to fill in the credit card form (paymen systems in the group `creditCardPaymentGroup`) update them to also call the function `setCardFormFilled` with `true` when the form is filled. So, we can validate it if the payments array have at least one payment selected and, if there is a credit card payment, to check for the `cardFormFilled` flag.

#### How to test it?

[Workspace](https://sndpurchase--checkoutio.myvtex.com/cart/add?sku=289).

Test plan:

1. Enter the above workspace and proceed to checkout.
2. Fill in with a second purchase email.
3. You should be redirected to the payment step.
4. Try to go to review ([quick url](https://sndpurchase--checkoutio.myvtex.com/checkout/#/)) and verify you can't.
5. Select the boleto payment and you should be redirected to review.
6. If you refresh the page, you should remain in review.
7. Select a credit card and fill in the details.
8. When in the review step, refresh the page and you should be redirected back to payment.

#### Describe alternatives you've considered, if any.

I also thought about using `post-robot` directly and calling to get the `isValid` from the iframe itself, instead of relying on this flag to be manually set, but I don't know how I feel about adding this dependency across different apps (it is currently only in `checkout-payment` and `checkout`).

#### Related to / Depends on

N/A