### PR TITLE
Feature free purchase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `isFreePurchase` and `lastStepsValid`properties to payment context.
+- `isFreePurchase` and `lastStepsValid` properties to payment context.
 
 ## [0.7.0] - 2020-07-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `isFreePurchase` property to payment context.
+- `isFreePurchase` and `lastStepsValid`properties to payment context.
 
 ## [0.7.0] - 2020-07-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `isFreePurchase` property to payment context.
 
 ## [0.7.0] - 2020-07-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `isFreePurchase` and `lastStepsValid` properties to payment context.
+- `isFreePurchase` property to payment context.
 
 ## [0.7.0] - 2020-07-13
 ### Added

--- a/react/OrderPayment.tsx
+++ b/react/OrderPayment.tsx
@@ -46,6 +46,7 @@ interface Context {
   paymentsValid: boolean
   setCardFormFilled: (filled: boolean) => void
   isFreePurchase: boolean
+  lastStepsValid: boolean
 }
 
 interface OrderPaymentProps {
@@ -96,9 +97,12 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
   const payment = payments?.[0] ?? {}
 
   const isFreePurchase = !referenceValue && orderForm.items.length > 0
+  const hasValidProfileData = orderForm.clientProfileData?.isValid ?? false
+  const hasValidShippingData = orderForm.shipping.isValid
+
+  const lastStepsValid = hasValidProfileData && hasValidShippingData
 
   const paymentsValid = useMemo(() => {
-
     if (isFreePurchase) {
       return true
     }
@@ -121,7 +125,7 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
     }
 
     return true
-  }, [cardFormFilled, paymentSystems, payments])
+  }, [cardFormFilled, isFreePurchase, paymentSystems, payments])
 
   const queueStatusRef = useQueueStatus(listen)
 
@@ -188,7 +192,8 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       setCardLastDigits,
       paymentsValid,
       setCardFormFilled,
-      isFreePurchase
+      isFreePurchase,
+      lastStepsValid,
     }),
     [
       setPaymentField,
@@ -201,7 +206,8 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       referenceValue,
       cardLastDigits,
       paymentsValid,
-      isFreePurchase
+      isFreePurchase,
+      lastStepsValid,
     ]
   )
 

--- a/react/OrderPayment.tsx
+++ b/react/OrderPayment.tsx
@@ -45,6 +45,7 @@ interface Context {
   setCardLastDigits: (cardDigits: string) => void
   paymentsValid: boolean
   setCardFormFilled: (filled: boolean) => void
+  isFreePurchase: boolean
 }
 
 interface OrderPaymentProps {
@@ -94,7 +95,14 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
 
   const payment = payments?.[0] ?? {}
 
+  const isFreePurchase = !referenceValue && orderForm.items.length > 0
+
   const paymentsValid = useMemo(() => {
+
+    if (isFreePurchase) {
+      return true
+    }
+
     if (!payments?.length) {
       return false
     }
@@ -180,6 +188,7 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       setCardLastDigits,
       paymentsValid,
       setCardFormFilled,
+      isFreePurchase
     }),
     [
       setPaymentField,
@@ -192,6 +201,7 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       referenceValue,
       cardLastDigits,
       paymentsValid,
+      isFreePurchase
     ]
   )
 

--- a/react/OrderPayment.tsx
+++ b/react/OrderPayment.tsx
@@ -46,7 +46,6 @@ interface Context {
   paymentsValid: boolean
   setCardFormFilled: (filled: boolean) => void
   isFreePurchase: boolean
-  lastStepsValid: boolean
 }
 
 interface OrderPaymentProps {
@@ -97,10 +96,6 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
   const payment = payments?.[0] ?? {}
 
   const isFreePurchase = !referenceValue && orderForm.items.length > 0
-  const hasValidProfileData = orderForm.clientProfileData?.isValid ?? false
-  const hasValidShippingData = orderForm.shipping.isValid
-
-  const lastStepsValid = hasValidProfileData && hasValidShippingData
 
   const paymentsValid = useMemo(() => {
     if (isFreePurchase) {
@@ -193,7 +188,6 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       paymentsValid,
       setCardFormFilled,
       isFreePurchase,
-      lastStepsValid,
     }),
     [
       setPaymentField,
@@ -207,7 +201,6 @@ export const OrderPaymentProvider: React.FC<OrderPaymentProps> = ({
       cardLastDigits,
       paymentsValid,
       isFreePurchase,
-      lastStepsValid,
     ]
   )
 

--- a/react/package.json
+++ b/react/package.json
@@ -20,10 +20,10 @@
     "@vtex/test-tools": "^1.1.0",
     "apollo-client": "^2.5.1",
     "typescript": "3.9.7",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql",
-    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.37.0/public/@types/vtex.checkout-resources",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime"
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.41.0/public/@types/vtex.checkout-resources",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime"
   },
   "version": "0.7.0"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^16.9.2",
     "@vtex/test-tools": "^1.1.0",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.33.3/public/@types/vtex.checkout-graphql",
     "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.29.0/public/@types/vtex.checkout-resources",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",

--- a/react/package.json
+++ b/react/package.json
@@ -20,10 +20,10 @@
     "@vtex/test-tools": "^1.1.0",
     "apollo-client": "^2.5.1",
     "typescript": "3.9.7",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.33.3/public/@types/vtex.checkout-graphql",
-    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.29.0/public/@types/vtex.checkout-resources",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.3/public/@types/vtex.render-runtime"
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.37.0/public/@types/vtex.checkout-resources",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime"
   },
   "version": "0.7.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4589,10 +4589,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.3.3333:
   version "3.5.3"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4705,21 +4705,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.33.3/public/@types/vtex.checkout-graphql":
-  version "0.33.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.33.3/public/@types/vtex.checkout-graphql#891164cdef46dd4c3b99237637131fd10e281ca8"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql":
+  version "0.46.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql#9a530005a9a190fda003221b6b0d94430b0527dd"
 
-"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.29.0/public/@types/vtex.checkout-resources":
-  version "0.29.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.29.0/public/@types/vtex.checkout-resources#586a55ba5f333bc84699a1572639f52209aa77a6"
+"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.37.0/public/@types/vtex.checkout-resources":
+  version "0.37.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.37.0/public/@types/vtex.checkout-resources#391726bdab0042610913ad691b3064f70462718b"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager":
-  version "0.8.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager#3a4761c73364853954dd61a61d1d01260cbbf634"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager":
+  version "0.8.7"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager#d666dbf9c6d630dba38ac26e815ffaa3811933df"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.3/public/@types/vtex.render-runtime":
-  version "8.100.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.3/public/@types/vtex.render-runtime#52b646c5e234ec1b95690ce59a6177ceddf84954"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime":
+  version "8.124.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime#8158e34bd24b4a51cb5d463eeef4e37af626c2d5"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4705,21 +4705,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql":
-  version "0.46.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql#9a530005a9a190fda003221b6b0d94430b0527dd"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
+  version "0.55.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql#a9f282941d74fffac3d3d877d92313dd755de07f"
 
-"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.37.0/public/@types/vtex.checkout-resources":
-  version "0.37.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.37.0/public/@types/vtex.checkout-resources#391726bdab0042610913ad691b3064f70462718b"
+"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.41.0/public/@types/vtex.checkout-resources":
+  version "0.41.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.41.0/public/@types/vtex.checkout-resources#e698a48b6a3e47e2d2219725dc5f3d9ab03ed664"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager":
-  version "0.8.7"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager#d666dbf9c6d630dba38ac26e815ffaa3811933df"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager":
+  version "0.9.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager#95626778e7cff8c8e70f0a3b09348937043f6d21"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime":
-  version "8.124.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime#8158e34bd24b4a51cb5d463eeef4e37af626c2d5"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime":
+  version "8.126.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime#f529e960313579c39a9748820885b995f9d6d3e6"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Add the free purchase feature to payment step. It's a scenario where the final purchase value is equal to 0. The user doesn’t need to choose a payment option to purchase.  

#### How to test it?

Choose the account `pilateslovers`. 
[App Store](https://pedrocheckout--extensions.myvtex.com/vtex-facebook-pixel/p)

I'm getting some issues to test the flow using `checkoutio` account because I can't choose a free shipping.  
[Checkout IO](https://pedrocheckout--checkoutio.myvtex.com/Produto-gratis/p)

#### Screenshots or example usage:
<img width="862" alt="Screen Shot 2020-11-16 at 9 48 53 AM" src="https://user-images.githubusercontent.com/32311264/99254393-0f2ad900-27f1-11eb-83e0-e3060ccd5ce2.png">

